### PR TITLE
make `require` statement compatible with node v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const rc = require('rc');
-const { execSync } = require('child_process');
+const execSync = require('child_process').execSync;
 
 const npm = rc('npm', null, []);
 


### PR DESCRIPTION
in `engines` field of `package.json` this project requires node >= 4
https://github.com/sapegin/user-meta/blob/de512873c8203a494b22c7b20ebdb96841245e3c/package.json#L12-L14

But object destructuring is incompatible with node v4